### PR TITLE
Added router for fission stablepay integration

### DIFF
--- a/gluon.json
+++ b/gluon.json
@@ -1,0 +1,825 @@
+[
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "vaultNameParam",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "baseAssetNameParam",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "baseAssetSymbolParam",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "peggedAssetNameParam",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "peggedAssetSymbolParam",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "baseTokenParam",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "pythOracleParam",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "priceIdParam",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "protonNameParam",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "protonSymbolParam",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "treasuryParam",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "fissionFeeParam",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "fusionFeeParam",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "criticalReserveRatioWadParam",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "BASE_TOKEN",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract IERC20"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "CRITICAL_RESERVE_RATIO",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "FISSION_FEE",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "FUSION_FEE",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "MAXIMUM_AGE",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "NEUTRON_TOKEN",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract Tokeon"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "PEGGED_ASSET_WAD",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "PRICE_ID",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "PROTON_TOKEN",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract Tokeon"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "PYTH_ORACLE",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract IPyth"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "TREASURY",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "WAD",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "baseAssetName",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "baseAssetSymbol",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "betaPhi0",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "betaPhi1",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "decayPerSecondWad",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "fission",
+    "inputs": [
+      {
+        "name": "amountIn",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "updateData",
+        "type": "bytes[]",
+        "internalType": "bytes[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "fusion",
+    "inputs": [
+      {
+        "name": "m",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "getBasePriceInPeggedAsset",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "neutronPriceInBase",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "neutronPriceInPeggedAsset",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "peggedAssetName",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "peggedAssetSymbol",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "protonPriceInBase",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "protonPriceInPeggedAsset",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "qWad",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "reserve",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "reserveRatioPeggedAsset",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "setBetaParams",
+    "inputs": [
+      {
+        "name": "phi0",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "phi1",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "decayPerSecondWadParam",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transmuteNeutronToProton",
+    "inputs": [
+      {
+        "name": "neutronIn",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "updateData",
+        "type": "bytes[]",
+        "internalType": "bytes[]"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "protonOut",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "feeWad",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "transmuteProtonToNeutron",
+    "inputs": [
+      {
+        "name": "protonIn",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "updateData",
+        "type": "bytes[]",
+        "internalType": "bytes[]"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "neutronOut",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "feeWad",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "updatePriceFeeds",
+    "inputs": [
+      {
+        "name": "updateData",
+        "type": "bytes[]",
+        "internalType": "bytes[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "vaultName",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "event",
+    "name": "BetaParamsSet",
+    "inputs": [
+      {
+        "name": "phi0",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "phi1",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "decayPerSecondWad",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Fission",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "baseIn",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "neutronOut",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "protonOut",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "feeToTreasury",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Fusion",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "neutronBurn",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "protonBurn",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "baseOut",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "feeToTreasury",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PriceUpdated",
+    "inputs": [
+      {
+        "name": "priceId",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "price",
+        "type": "int64",
+        "indexed": false,
+        "internalType": "int64"
+      },
+      {
+        "name": "timestamp",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "TransmuteMinus",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "neutronIn",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "protonOut",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "feeWad",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "newDecayedVolumeBase",
+        "type": "int256",
+        "indexed": false,
+        "internalType": "int256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "TransmutePlus",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "protonIn",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "neutronOut",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "feeWad",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "newDecayedVolumeBase",
+        "type": "int256",
+        "indexed": false,
+        "internalType": "int256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "ReentrancyGuardReentrantCall",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "SafeERC20FailedOperation",
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  }
+]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "Gluon-EVM",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/src/GluonPaymentRouter.sol
+++ b/src/GluonPaymentRouter.sol
@@ -24,6 +24,7 @@ contract GluonPaymentRouter {
     IERC20 public proton;
 
     constructor(address _gluon) {
+        require(_gluon != address(0), "Gluon: zero address");
         gluon = IGluon(_gluon);
         neutron = IERC20(gluon.NEUTRON_TOKEN());
         proton = IERC20(gluon.PROTON_TOKEN());
@@ -35,6 +36,7 @@ contract GluonPaymentRouter {
      * @param updateData Pyth oracle update data (if needed).
      */
     function payWithFission(address merchant, bytes[] calldata updateData) external payable {
+        require(merchant != address(0), "payWithFission: merchant is zero address");
         // 1. Perform Fission, minting both tokens to this contract
         gluon.fission{value: msg.value}(msg.value, address(this), updateData);
 

--- a/src/GluonPaymentRouter.sol
+++ b/src/GluonPaymentRouter.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IERC20 {
+    function transfer(address to, uint256 amount) external returns (bool);
+    function balanceOf(address account) external view returns (uint256);
+}
+
+interface IGluon {
+    function fission(uint256 amountIn, address to, bytes[] calldata updateData) external payable;
+    function NEUTRON_TOKEN() external view returns (address);
+    function PROTON_TOKEN() external view returns (address);
+}
+
+/**
+ * @title GluonPaymentRouter
+ * @notice Helper contract to split Fission outputs:
+ *         - Neutrons (Stable) -> Sent to Merchant
+ *         - Protons (Volatile) -> Returned to User (Payer)
+ */
+contract GluonPaymentRouter {
+    IGluon public gluon;
+    IERC20 public neutron;
+    IERC20 public proton;
+
+    constructor(address _gluon) {
+        gluon = IGluon(_gluon);
+        neutron = IERC20(gluon.NEUTRON_TOKEN());
+        proton = IERC20(gluon.PROTON_TOKEN());
+    }
+
+    /**
+     * @notice Performs fission with the attached value, sends Neutrons to merchant, returns Protons to sender.
+     * @param merchant The address of the merchant to receive the stable payment.
+     * @param updateData Pyth oracle update data (if needed).
+     */
+    function payWithFission(address merchant, bytes[] calldata updateData) external payable {
+        // 1. Perform Fission, minting both tokens to this contract
+        gluon.fission{value: msg.value}(msg.value, address(this), updateData);
+
+        // 2. Determine amounts minted
+        uint256 nBal = neutron.balanceOf(address(this));
+        uint256 pBal = proton.balanceOf(address(this));
+
+        // 3. Forward Neutrons to Merchant
+        if (nBal > 0) {
+            neutron.transfer(merchant, nBal);
+        }
+
+        // 4. Return Protons to Payer (User)
+        if (pBal > 0) {
+            proton.transfer(msg.sender, pBal);
+        }
+    }
+    
+    // Allow contract to receive ETH if needed (though fission usually consumes it)
+    receive() external payable {}
+}

--- a/test/GluonPaymentRouter.t.sol
+++ b/test/GluonPaymentRouter.t.sol
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+import "../src/GluonPaymentRouter.sol";
+
+// Mock ERC20
+contract MockToken is IERC20 {
+    mapping(address => uint256) public balances;
+
+    function balanceOf(address account) external view override returns (uint256) {
+        return balances[account];
+    }
+
+    function transfer(address to, uint256 amount) external override returns (bool) {
+        balances[msg.sender] -= amount;
+        balances[to] += amount;
+        return true;
+    }
+
+    function mint(address to, uint256 amount) external {
+        balances[to] += amount;
+    }
+}
+
+// Mock Gluon Reactor
+contract MockGluon is IGluon {
+    address public neutron;
+    address public proton;
+
+    constructor(address _neutron, address _proton) {
+        neutron = _neutron;
+        proton = _proton;
+    }
+
+    function NEUTRON_TOKEN() external view override returns (address) {
+        return neutron;
+    }
+
+    function PROTON_TOKEN() external view override returns (address) {
+        return proton;
+    }
+
+    function fission(uint256 amountIn, address to, bytes[] calldata) external payable override {
+        // Mock behavior: Mint 50 Neutrons and 50 Protons to 'to'
+        // In real life, amounts depend on math, but for Router testing,
+        // we just care that Router receives tokens and forwards them.
+        MockToken(neutron).mint(to, 50 ether);
+        MockToken(proton).mint(to, 50 ether);
+    }
+}
+
+contract GluonPaymentRouterTest is Test {
+    GluonPaymentRouter router;
+    MockGluon gluon;
+    MockToken neutron;
+    MockToken proton;
+
+    address user = address(0x123);
+    address merchant = address(0x456);
+
+    function setUp() public {
+        neutron = new MockToken();
+        proton = new MockToken();
+        gluon = new MockGluon(address(neutron), address(proton));
+        router = new GluonPaymentRouter(address(gluon));
+        
+        // Fund user
+        vm.deal(user, 10 ether);
+    }
+
+    function testPayWithFissionMovesTokensCorrectly() public {
+        // 1. Arrange
+        uint256 payAmount = 1 ether;
+        bytes[] memory data = new bytes[](0);
+
+        // 2. Act
+        vm.prank(user);
+        router.payWithFission{value: payAmount}(merchant, data);
+
+        // 3. Assert
+        
+        // Merchant should receive Neutrons
+        assertEq(neutron.balanceOf(merchant), 50 ether, "Merchant should get Neutrons");
+        assertEq(neutron.balanceOf(user), 0, "User should NOT get Neutrons");
+        assertEq(neutron.balanceOf(address(router)), 0, "Router should typically be empty");
+
+        // User should receive Protons (Refunded)
+        assertEq(proton.balanceOf(user), 50 ether, "User should get Protons");
+        assertEq(proton.balanceOf(merchant), 0, "Merchant should NOT get Protons");
+        assertEq(proton.balanceOf(address(router)), 0, "Router should typically be empty");
+    }
+}


### PR DESCRIPTION
I created a new helper smart contract GluonPaymentRouter.sol in src. 
- This contract serves as a payment wrapper that:
- Accepts a native payment from the user.
- Performs a Fission operation on the Gluon Vault.
- Automatically forwards the stable Neutrons to the intended merchant.
- Returns the volatile/speculative Protons back to the user (the payer), enabling them to retain the “long” position on the asset they just spent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a payment router that accepts native ETH, triggers a minting operation, forwards Neutron tokens to a merchant, and returns Proton tokens to the payer.
  * Added a public ABI-like JSON payload describing the protocol's constructor, functions, events, and errors for integration.

* **Tests**
  * Added end-to-end tests validating the pay-and-distribute flow, token minting, and correct token routing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->