### PR TITLE
align IOracle read function names

### DIFF
--- a/src/StableCoin.sol
+++ b/src/StableCoin.sol
@@ -152,7 +152,7 @@ contract StableCoinReactor is ReentrancyGuard {
     /// @dev Base/PeggedAsset price (WAD).
     /// Delegates to the Oracle Adapter.
     function getBasePriceInPeggedAsset() public view returns (uint256) {
-        return ORACLE.getValue();
+        return ORACLE.readValue();
     }
 
     function qWad() public view returns (uint256) {

--- a/src/interfaces/IOracle.sol
+++ b/src/interfaces/IOracle.sol
@@ -5,13 +5,13 @@ pragma solidity ^0.8.20;
 // values are WAD, implementer handles scaling
 interface IOracle {
     // latest value in WAD
-    function getValue() external view returns (uint256 value);
+    function readValue() external view returns (uint256 value);
 
     // upper value in WAD
-    function getMaxValue() external view returns (uint256 maxValue);
+    function readMaxValue() external view returns (uint256 maxValue);
 
     // lower value in WAD
-    function getMinValue() external view returns (uint256 minValue);
+    function readMinValue() external view returns (uint256 minValue);
 
     // when value was last updated
     function lastUpdated() external view returns (uint256 timestamp);

--- a/src/oracles/ChainlinkToOracleAdapter.sol
+++ b/src/oracles/ChainlinkToOracleAdapter.sol
@@ -24,7 +24,7 @@ contract ChainlinkToOracleAdapter is IOracle {
     }
 
     // reads chainlink answer and scales to WAD
-    function getValue() public view returns (uint256 value) {
+    function readValue() public view returns (uint256 value) {
         (, int256 answer,,,) = feed.latestRoundData();
         require(answer > 0, "bad value");
         // casting is safe because answer > 0
@@ -33,12 +33,12 @@ contract ChainlinkToOracleAdapter is IOracle {
     }
 
     // chainlink has single value, so min = max = value
-    function getMaxValue() external view returns (uint256 maxValue) {
-        return getValue();
+    function readMaxValue() external view returns (uint256 maxValue) {
+        return readValue();
     }
 
-    function getMinValue() external view returns (uint256 minValue) {
-        return getValue();
+    function readMinValue() external view returns (uint256 minValue) {
+        return readValue();
     }
 
     // last update timestamp from chainlink

--- a/test/ChainlinkAdapter.t.sol
+++ b/test/ChainlinkAdapter.t.sol
@@ -34,27 +34,27 @@ contract ChainlinkAdapterTest is Test {
         // $50000 with 8 decimals
         MockChainlinkFeed feed = new MockChainlinkFeed(8, 50000 * 1e8);
         ChainlinkToOracleAdapter adapter = new ChainlinkToOracleAdapter(address(feed));
-        assertEq(adapter.getValue(), 50000 * 1e18, "8 dec scaling failed");
+        assertEq(adapter.readValue(), 50000 * 1e18, "8 dec scaling failed");
     }
 
     function testSupportsEighteenDecimals() public {
         MockChainlinkFeed feed = new MockChainlinkFeed(18, 2000 * 1e18);
         ChainlinkToOracleAdapter adapter = new ChainlinkToOracleAdapter(address(feed));
-        assertEq(adapter.getValue(), 2000 * 1e18, "18 dec scaling failed");
+        assertEq(adapter.readValue(), 2000 * 1e18, "18 dec scaling failed");
     }
 
     function testSupportsMoreThanEighteenDecimals() public {
         // 20 decimals, should divide down to WAD
         MockChainlinkFeed feed = new MockChainlinkFeed(20, 2000 * 1e20);
         ChainlinkToOracleAdapter adapter = new ChainlinkToOracleAdapter(address(feed));
-        assertEq(adapter.getValue(), 2000 * 1e18, "20 dec scaling failed");
+        assertEq(adapter.readValue(), 2000 * 1e18, "20 dec scaling failed");
     }
 
     function testMinAndMaxEqualValue() public {
         MockChainlinkFeed feed = new MockChainlinkFeed(8, 100 * 1e8);
         ChainlinkToOracleAdapter adapter = new ChainlinkToOracleAdapter(address(feed));
-        assertEq(adapter.getMinValue(), adapter.getValue(), "min != value");
-        assertEq(adapter.getMaxValue(), adapter.getValue(), "max != value");
+        assertEq(adapter.readMinValue(), adapter.readValue(), "min != value");
+        assertEq(adapter.readMaxValue(), adapter.readValue(), "max != value");
     }
 
     function testLastUpdatedReturnsFeedTimestamp() public {
@@ -67,7 +67,7 @@ contract ChainlinkAdapterTest is Test {
         MockChainlinkFeed feed = new MockChainlinkFeed(8, 0);
         ChainlinkToOracleAdapter adapter = new ChainlinkToOracleAdapter(address(feed));
         vm.expectRevert("bad value");
-        adapter.getValue();
+        adapter.readValue();
     }
 
     function testRevertsOnZeroFeedAddress() public {
@@ -80,21 +80,21 @@ contract ChainlinkAdapterTest is Test {
         ChainlinkToOracleAdapter adapter = new ChainlinkToOracleAdapter(address(feed));
 
         vm.expectRevert("bad value");
-        adapter.getValue();
+        adapter.readValue();
     }
 
     function testScalesSixDecimalsToWad() public {
         MockChainlinkFeed feed = new MockChainlinkFeed(6, 1234 * 1e6);
         ChainlinkToOracleAdapter adapter = new ChainlinkToOracleAdapter(address(feed));
 
-        assertEq(adapter.getValue(), 1234 * 1e18, "6 dec scaling failed");
+        assertEq(adapter.readValue(), 1234 * 1e18, "6 dec scaling failed");
     }
 
     function testScalesZeroDecimalsToWad() public {
         MockChainlinkFeed feed = new MockChainlinkFeed(0, 1234);
         ChainlinkToOracleAdapter adapter = new ChainlinkToOracleAdapter(address(feed));
 
-        assertEq(adapter.getValue(), 1234 * 1e18, "0 dec scaling failed");
+        assertEq(adapter.readValue(), 1234 * 1e18, "0 dec scaling failed");
     }
 
     function testDescriptionReturnsFeedDescription() public {


### PR DESCRIPTION
###  Addressed Issues:

N/A


###  Screenshots/Recordings:

N/A. This PR only updates Solidity interface/function names.


###  Additional Notes:
<!-- Add any additional information, context, or notes for reviewers -->

This PR aligns the current `IOracle` API with the updated oracle naming.

Changes:
- Renamed `getValue()` to `readValue()`
- Renamed `getMaxValue()` to `readMaxValue()`
- Renamed `getMinValue()` to `readMinValue()`
- Updated the Chainlink adapter to use the new names
- Updated the reactor oracle call to use `readValue()`
- Updated Chainlink adapter tests to use the new names

No oracle logic is changed in this PR.

Local checks:
- `forge fmt`
- `forge build`
- `forge test`

Current result:
- 20 tests passed, 0 failed, 0 skipped


### AI Usage Disclosure:

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.

Check one of the checkboxes below:

- [ ] This PR does not contain AI-generated code at all.
- [ ] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [ ] If applicable, I have made corresponding changes or additions to the documentation
- [x] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated price-reading calls to use the latest oracle interface, keeping value lookups working with the current adapter behavior.
  * Adjusted oracle value access across the app to support the renamed read methods.
  * Preserved existing pricing logic and return values while aligning with the new API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->