### PR TITLE
refactor: replace oracle min max reads with interval

### DIFF
--- a/src/interfaces/IOracle.sol
+++ b/src/interfaces/IOracle.sol
@@ -7,11 +7,8 @@ interface IOracle {
     // latest value in WAD
     function readValue() external view returns (uint256 value);
 
-    // upper value in WAD
-    function readMaxValue() external view returns (uint256 maxValue);
-
-    // lower value in WAD
-    function readMinValue() external view returns (uint256 minValue);
+    // lower and upper values in WAD
+    function readValueInterval() external view returns (uint256 minValue, uint256 maxValue);
 
     // when value was last updated
     function lastUpdated() external view returns (uint256 timestamp);

--- a/src/oracles/ChainlinkToOracleAdapter.sol
+++ b/src/oracles/ChainlinkToOracleAdapter.sol
@@ -34,13 +34,10 @@ contract ChainlinkToOracleAdapter is IOracle {
         return _scaleToWad(uint256(answer), feed.decimals());
     }
 
-    // chainlink has single value, so min = max = value
-    function readMaxValue() external view returns (uint256 maxValue) {
-        return readValue();
-    }
-
-    function readMinValue() external view returns (uint256 minValue) {
-        return readValue();
+    // Chainlink provides one value, so min and max are equal
+    function readValueInterval() external view returns (uint256 minValue, uint256 maxValue) {
+        uint256 value = readValue();
+        return (value, value);
     }
 
     // last update timestamp from chainlink

--- a/test/ChainlinkAdapter.t.sol
+++ b/test/ChainlinkAdapter.t.sol
@@ -50,11 +50,14 @@ contract ChainlinkAdapterTest is Test {
         assertEq(adapter.readValue(), 2000 * 1e18, "20 dec scaling failed");
     }
 
-    function testMinAndMaxEqualValue() public {
+    function testValueIntervalEqualsValue() public {
         MockChainlinkFeed feed = new MockChainlinkFeed(8, 100 * 1e8);
         ChainlinkToOracleAdapter adapter = new ChainlinkToOracleAdapter(address(feed));
-        assertEq(adapter.readMinValue(), adapter.readValue(), "min != value");
-        assertEq(adapter.readMaxValue(), adapter.readValue(), "max != value");
+
+        (uint256 minValue, uint256 maxValue) = adapter.readValueInterval();
+
+        assertEq(minValue, adapter.readValue(), "min != value");
+        assertEq(maxValue, adapter.readValue(), "max != value");
     }
 
     function testLastUpdatedReturnsFeedTimestamp() public {

--- a/test/GenericIOracleIntegration.t.sol
+++ b/test/GenericIOracleIntegration.t.sol
@@ -40,12 +40,8 @@ contract GenericMockOracle is IOracle {
         return value;
     }
 
-    function readMaxValue() external view returns (uint256) {
-        return maxValue;
-    }
-
-    function readMinValue() external view returns (uint256) {
-        return minValue;
+    function readValueInterval() external view returns (uint256 minValue_, uint256 maxValue_) {
+        return (minValue, maxValue);
     }
 
     function lastUpdated() external view returns (uint256) {
@@ -66,6 +62,15 @@ contract GenericIOracleIntegrationTest is Test {
     function setUp() public {
         factory = new StableCoinFactory();
         baseToken = new GenericMockERC20();
+    }
+
+    function testGenericOracleReturnsValueInterval() public {
+        GenericMockOracle oracle = new GenericMockOracle(1e18);
+
+        (uint256 minValue, uint256 maxValue) = oracle.readValueInterval();
+
+        assertEq(minValue, 1e18);
+        assertEq(maxValue, 1e18);
     }
 
     function testFactoryDeploysReactorWithGenericIOracle() public {


### PR DESCRIPTION
### Summary

Replaces the separate `readMinValue()` and `readMaxValue()` functions in `IOracle` with a single `readValueInterval()` function.

The existing Chainlink oracle implementation, generic oracle mock, and related tests have been updated to use the revised interface.

### Addressed Issues:

N/A. This change follows the agreed oracle interface update.

### Screenshots/Recordings:

Not applicable. This PR does not contain any UI changes.

### Additional Notes:

- `readValueInterval()` returns `(minValue, maxValue)`.
- Since Chainlink provides a single latest value, `ChainlinkToOracleAdapter` returns that value as both the minimum and maximum.
- Direct OrbOracle integration will be handled in a separate PR.
- No reactor pricing logic was changed in this PR.

### Testing:

- `forge fmt --check`
- `forge build --force`
- `forge test`
- `git diff --check`

All 26 tests pass.

### AI Usage Disclosure:

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.

Check one of the checkboxes below:

- [ ] This PR does not contain AI-generated code at all.
- [x] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

## Checklist

- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [x] If applicable, I have made corresponding changes or additions to the documentation
- [x] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Oracle integrations now provide minimum and maximum values together through a single value-interval reading.
  * Chainlink-based readings return matching lower and upper bounds from one price query.

* **Bug Fixes**
  * Updated oracle integrations and validation to consistently use the unified interval response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->